### PR TITLE
Add KDoc to generated typealias

### DIFF
--- a/usekase-processor/src/main/java/guru/stefma/cleancomponents/processor/usecase/GeneratedClass.kt
+++ b/usekase-processor/src/main/java/guru/stefma/cleancomponents/processor/usecase/GeneratedClass.kt
@@ -24,8 +24,11 @@ internal data class GeneratedClass(
         private val messager: Messager,
         private val _className: String,
         val classPackage: String,
-        private val fullName: String
+        private val fullName: String,
+        private val _documentation: String?
 ) {
+
+    val documentation = _documentation ?: ""
 
     val fileName by lazy {
         "${className}TypeAlias"


### PR DESCRIPTION
![unbenannt](https://user-images.githubusercontent.com/14896745/39429102-1fd33986-4c8a-11e8-8dd4-eacd496d8c0d.png)

Little workaround as the stars from the KDoc were also being extracted, so reading
```
/**
 * Text
 */
```` 
would give 
```
/**
 * * Text
 */
```` 

Closes #14 