### PR TITLE
add None for UseCases which do not need any parameters

### DIFF
--- a/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
+++ b/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
@@ -14,4 +14,18 @@ interface CoroutineUseCase<R, P> {
 
     suspend fun execute(params: P): R
 
+    /**
+     * For UseCases which don't need any parameters:
+     * ```
+     * MyUseCase : UseCase<Result, UseCase.None> {
+     *
+     *     override fun execute(params: None): Result { /* ... */ }
+     *
+     *     /* ... */
+     * }
+     *
+     * MyUseCase().execute(UseCase.None)
+     * ```
+     */
+    object None
 }

--- a/usekase/src/main/java/guru/stefma/cleancomponents/usecase/UseCase.kt
+++ b/usekase/src/main/java/guru/stefma/cleancomponents/usecase/UseCase.kt
@@ -15,4 +15,19 @@ interface UseCase<R, P> {
     fun buildUseCase(params: P): R
 
     fun execute(params: P) = buildUseCase(params)
+
+    /**
+     * For UseCases which don't need any parameters:
+     * ```
+     * MyUseCase : UseCase<Result, UseCase.None> {
+     *
+     *     override fun execute(params: None): Result { /* ... */ }
+     *
+     *     /* ... */
+     * }
+     *
+     * MyUseCase().execute(UseCase.None)
+     * ```
+     */
+    object None
 }


### PR DESCRIPTION
Adds an `object None` for use cases which don't need input parameters.

Usage:
```
MyUseCase : UseCase<Result, UseCase.None> {

    override fun execute(params: None): Result { /* ... */ }

    /* ... */
}

MyUseCase().execute(UseCase.None)
 ```
