### PR TITLE
Enhance coroutine use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ GlobalScope.launch {
 However, the module currently uses the experimental `Result` class as a return type. You need to enable this first
 by putting this in your `build.gradle.kts`:
 ```groovy
-tasks.withType(KotlinCompile::class.java).all {
+tasks.withType(KotlinCompile::class.java).configureEach {
     kotlinOptions.apply {
         jvmTarget = "1.8"
         freeCompilerArgs = listOf("-Xallow-result-return-type")

--- a/README.md
+++ b/README.md
@@ -76,3 +76,40 @@ All available `UseCase` implementations are:
 * `ObservableUseCase<R, P>`
 * `MaybeUseCase<R, P>`
 * `CompletableUseCase<P>`
+
+### Kotlin coroutine version
+The `usekase-coroutines` module offers a base use case class `CoroutineUseCase` that you can extend:
+```kotlin
+@UseCase
+class GetUserCoroutineUseCase(
+    override val callbackDispatcher: CoroutineContext = Dispatchers.IO
+) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params>() {
+
+    override suspend fun execute(params: Params): Result<User> {
+        return Result.success(User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString()))
+    }
+
+    data class Params(val userId: String)
+}
+```
+
+You have to execute it from a `CoroutineScope` like this:
+```kotlin
+GlobalScope.launch {
+  getUserCoroutine(
+    onFailure = { },
+    onError = { }
+  )
+}
+```
+
+However, the module currently uses the experimental `Result` class as a return type. You need to enable this first
+by putting this in your `build.gradle.kts`:
+```groovy
+tasks.withType(KotlinCompile::class.java).all {
+    kotlinOptions.apply {
+        jvmTarget = "1.8"
+        freeCompilerArgs = listOf("-Xallow-result-return-type")
+    }
+}
+```

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm") version "1.3.21"
     kotlin("kapt") version "1.3.21"
@@ -29,4 +31,11 @@ sourceSets {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.withType(KotlinCompile::class.java).all {
+    kotlinOptions.apply {
+        jvmTarget = "1.8"
+        freeCompilerArgs = listOf("-Xallow-result-return-type")
+    }
 }

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.21"
-    kotlin("kapt") version "1.3.21"
+    kotlin("jvm") version "1.3.41"
+    kotlin("kapt") version "1.3.41"
 }
 
 repositories {
@@ -13,12 +13,12 @@ dependencies {
     implementation(project(":usekase-rx"))
     implementation(project(":usekase-coroutines"))
     kapt(project(":usekase-processor"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.21")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.41")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testImplementation("org.assertj:assertj-core:3.12.1")
+    testImplementation("org.assertj:assertj-core:3.12.2")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.2")
 }
 
 // Add generated kapt source code to main sourceSet

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1")
 }
 
 // Add generated kapt source code to main sourceSet

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-tasks.withType(KotlinCompile::class.java).all {
+tasks.withType(KotlinCompile::class.java).configureEach {
     kotlinOptions.apply {
         jvmTarget = "1.8"
         freeCompilerArgs = listOf("-Xallow-result-return-type")

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -14,8 +14,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.21")
     // This is for usekase-rx
     implementation("io.reactivex.rxjava2:rxjava:2.2.7")
-    // This is for usekase-coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")

--- a/samples/jvm/build.gradle.kts
+++ b/samples/jvm/build.gradle.kts
@@ -14,8 +14,6 @@ dependencies {
     implementation(project(":usekase-coroutines"))
     kapt(project(":usekase-processor"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.21")
-    // This is for usekase-rx
-    implementation("io.reactivex.rxjava2:rxjava:2.2.7")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")

--- a/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
+++ b/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
@@ -66,7 +66,7 @@ class GetUsePointsForUserIdUseCase(
 @UseCase
 class GetUserCoroutineUseCase(
     override val callbackDispatcher: CoroutineContext = Dispatchers.Default
-) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params>() {
+) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params> {
 
     override suspend fun execute(params: Params): Result<User> {
         return Result.success(User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString()))
@@ -79,11 +79,12 @@ class GetUserCoroutineUseCase(
 class GetUsePointsForUserIdCoroutineUseCase(
     private val getUser: GetUserCoroutine,
     override val callbackDispatcher: CoroutineContext = Dispatchers.Default
-) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params>() {
+) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params> {
 
     override suspend fun execute(params: Params): Result<Int> {
-        val user = getUser.execute(GetUserCoroutineUseCase.Params(params.userId)).getOrThrow()
-        return Result.success(user.authorizationKey.run { 99 })
+        return getUser.execute(GetUserCoroutineUseCase.Params(params.userId))
+            .map { it.authorizationKey }
+            .map { 99 }
     }
 
     data class Params(val userId: String)

--- a/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
+++ b/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
@@ -3,21 +3,24 @@ package guru.stefma.cleancomponents.usecase.sample.jvm
 import guru.stefma.cleancomponents.usecase.annotation.UseCase
 import guru.stefma.cleancomponents.usecase.coroutines.CoroutineUseCase
 import guru.stefma.cleancomponents.usecase.rx.SingleUseCase
+import guru.stefma.cleancomponents.usecase.sample.jvm.Gender.MALE
 import guru.stefma.cleancomponents.usecase.sample.jvm.GetUserUseCase.Params
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
-import java.util.*
+import kotlinx.coroutines.Dispatchers
+import java.util.Random
+import kotlin.coroutines.CoroutineContext
 
 enum class Gender {
     MALE, FEMALE
 }
 
 data class User(
-        val id: String,
-        val name: String,
-        val gender: Gender,
-        val authorizationKey: String
+    val id: String,
+    val name: String,
+    val gender: Gender,
+    val authorizationKey: String
 )
 
 /**
@@ -25,8 +28,8 @@ data class User(
  */
 @UseCase
 class GetUserUseCase(
-        override val executionScheduler: Scheduler = Schedulers.io(),
-        override val postExecutionScheduler: Scheduler = Schedulers.trampoline()
+    override val executionScheduler: Scheduler = Schedulers.io(),
+    override val postExecutionScheduler: Scheduler = Schedulers.trampoline()
 ) : SingleUseCase<User, Params> {
 
     override fun buildUseCase(params: GetUserUseCase.Params): Single<User> {
@@ -43,44 +46,45 @@ class GetUserUseCase(
  */
 @UseCase
 class GetUsePointsForUserIdUseCase(
-        private val getUser: GetUser,
-        override val executionScheduler: Scheduler,
-        override val postExecutionScheduler: Scheduler
+    private val getUser: GetUser,
+    override val executionScheduler: Scheduler,
+    override val postExecutionScheduler: Scheduler
 ) : SingleUseCase<Int, GetUsePointsForUserIdUseCase.Params> {
 
     override fun buildUseCase(params: GetUsePointsForUserIdUseCase.Params): Single<Int> {
         return getUser.buildUseCase(
-                guru.stefma.cleancomponents.usecase.sample.jvm.GetUserUseCase.Params(params.userId))
-                .flatMap {
-                    Single.just(it.authorizationKey)
-                            .map { 99 }
-                }
-    }
-
-    data class Params(val userId: String)
-}
-
-@UseCase
-class GetUserCoroutineUseCase : CoroutineUseCase<User, GetUserCoroutineUseCase.Params> {
-
-    override suspend fun execute(params: Params): User {
-        return User(params.userId, "Thorsten", Gender.MALE, Random().nextInt(1000).toString())
-    }
-
-    data class Params(val userId: String)
-
-}
-
-@UseCase
-class GetUsePointsForUserIdCoroutineUseCase(private val getUser: GetUserCoroutine) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params> {
-
-    override suspend fun execute(params: Params): Int {
-        val user = getUser.execute(GetUserCoroutineUseCase.Params(params.userId))
-        return user.authorizationKey.run {
-            99
+            GetUserUseCase.Params(params.userId)
+        ).flatMap {
+            Single.just(it.authorizationKey)
+                .map { 99 }
         }
     }
 
     data class Params(val userId: String)
+}
 
+@UseCase
+class GetUserCoroutineUseCase(
+    override val callbackDispatcher: CoroutineContext = Dispatchers.IO
+) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params>() {
+
+    override suspend fun execute(params: Params): User {
+        return User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString())
+    }
+
+    data class Params(val userId: String)
+}
+
+@UseCase
+class GetUsePointsForUserIdCoroutineUseCase(
+    private val getUser: GetUserCoroutine,
+    override val callbackDispatcher: CoroutineContext = Dispatchers.IO
+) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params>() {
+
+    override suspend fun execute(params: Params): Int {
+        val user = getUser.execute(GetUserCoroutineUseCase.Params(params.userId))
+        return user.authorizationKey.run { 99 }
+    }
+
+    data class Params(val userId: String)
 }

--- a/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
+++ b/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
@@ -68,8 +68,8 @@ class GetUserCoroutineUseCase(
     override val callbackDispatcher: CoroutineContext = Dispatchers.IO
 ) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params>() {
 
-    override suspend fun execute(params: Params): User {
-        return User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString())
+    override suspend fun execute(params: Params): Result<User> {
+        return Result.success(User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString()))
     }
 
     data class Params(val userId: String)
@@ -81,9 +81,9 @@ class GetUsePointsForUserIdCoroutineUseCase(
     override val callbackDispatcher: CoroutineContext = Dispatchers.IO
 ) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params>() {
 
-    override suspend fun execute(params: Params): Int {
-        val user = getUser.execute(GetUserCoroutineUseCase.Params(params.userId))
-        return user.authorizationKey.run { 99 }
+    override suspend fun execute(params: Params): Result<Int> {
+        val user = getUser.execute(GetUserCoroutineUseCase.Params(params.userId)).getOrThrow()
+        return Result.success(user.authorizationKey.run { 99 })
     }
 
     data class Params(val userId: String)

--- a/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
+++ b/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
@@ -65,7 +65,7 @@ class GetUsePointsForUserIdUseCase(
 
 @UseCase
 class GetUserCoroutineUseCase(
-    override val callbackDispatcher: CoroutineContext = Dispatchers.IO
+    override val callbackDispatcher: CoroutineContext = Dispatchers.Default
 ) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params>() {
 
     override suspend fun execute(params: Params): Result<User> {
@@ -78,7 +78,7 @@ class GetUserCoroutineUseCase(
 @UseCase
 class GetUsePointsForUserIdCoroutineUseCase(
     private val getUser: GetUserCoroutine,
-    override val callbackDispatcher: CoroutineContext = Dispatchers.IO
+    override val callbackDispatcher: CoroutineContext = Dispatchers.Default
 ) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params>() {
 
     override suspend fun execute(params: Params): Result<Int> {

--- a/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
+++ b/samples/jvm/src/main/java/guru/stefma/cleancomponents/usecase/sample/jvm/Sample.kt
@@ -68,7 +68,7 @@ class GetUserCoroutineUseCase(
     override val callbackDispatcher: CoroutineContext = Dispatchers.Default
 ) : CoroutineUseCase<User, GetUserCoroutineUseCase.Params> {
 
-    override suspend fun execute(params: Params): Result<User> {
+    override suspend fun buildUseCase(params: Params): Result<User> {
         return Result.success(User(params.userId, "Thorsten", MALE, Random().nextInt(1000).toString()))
     }
 
@@ -81,8 +81,8 @@ class GetUsePointsForUserIdCoroutineUseCase(
     override val callbackDispatcher: CoroutineContext = Dispatchers.Default
 ) : CoroutineUseCase<Int, GetUsePointsForUserIdCoroutineUseCase.Params> {
 
-    override suspend fun execute(params: Params): Result<Int> {
-        return getUser.execute(GetUserCoroutineUseCase.Params(params.userId))
+    override suspend fun buildUseCase(params: Params): Result<Int> {
+        return getUser.buildUseCase(GetUserCoroutineUseCase.Params(params.userId))
             .map { it.authorizationKey }
             .map { 99 }
     }

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
@@ -1,18 +1,22 @@
 package guru.stefma.cleancomponents.usecase.sample.jvm
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import guru.stefma.cleancomponents.usecase.sample.jvm.Gender.FEMALE
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestCoroutineContext
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.*
 
 @ObsoleteCoroutinesApi
 class GetUsePointsForUserIdCoroutineUseCaseTest {
 
-    private val testContext = TestCoroutineContext()
+    private val testContext = TestCoroutineScope()
 
     private val mockGetUser = mock<GetUserCoroutine>()
 
@@ -21,12 +25,12 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
     @Test
     fun `test get points successfully`() {
         val user = User("id", "Name", FEMALE, "anyKey")
-        coroutineScope.launch { whenever(mockGetUser.execute(any())) doReturn user }
+        coroutineScope.launch { whenever(mockGetUser.execute(any())) doReturn Result.success(user) }
         val useCase = GetUsePointsForUserIdCoroutineUseCase(mockGetUser)
         var points: Int? = null
 
         coroutineScope.launch {
-            points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId"))
+            points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId")).getOrNull()
         }
 
         testContext.triggerActions()
@@ -40,7 +44,7 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
         var points: Int? = null
 
         coroutineScope.launch {
-            points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId"))
+            points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId")).getOrNull()
         }
 
         testContext.triggerActions()

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
@@ -22,7 +22,7 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
     @Test
     fun `test get points successfully`() {
         val user = User("id", "Name", FEMALE, "anyKey")
-        coroutineScope.launch { whenever(mockGetUser.execute(any())) doReturn Result.success(user) }
+        coroutineScope.launch { whenever(mockGetUser.buildUseCase(any())) doReturn Result.success(user) }
         val useCase = GetUsePointsForUserIdCoroutineUseCase(mockGetUser)
         var points: Int? = null
 
@@ -38,7 +38,7 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
     @Test
     fun `test get points on error`() = runBlockingTest {
         val throwable = Throwable()
-        whenever(mockGetUser.execute(any())) doReturn Result.failure(throwable)
+        whenever(mockGetUser.buildUseCase(any())) doReturn Result.failure(throwable)
         val useCase = GetUsePointsForUserIdCoroutineUseCase(mockGetUser)
         var points: Int? = null
         var exception: Throwable? = null

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import guru.stefma.cleancomponents.usecase.sample.jvm.Gender.FEMALE
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.*
@@ -22,7 +21,7 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
     @Test
     fun `test get points successfully`() {
         val user = User("id", "Name", FEMALE, "anyKey")
-        coroutineScope.launch { whenever(mockGetUser.buildUseCase(any())) doReturn Result.success(user) }
+        coroutineScope.runBlockingTest { whenever(mockGetUser.buildUseCase(any())) doReturn Result.success(user) }
         val useCase = GetUsePointsForUserIdCoroutineUseCase(mockGetUser)
         var points: Int? = null
 
@@ -36,18 +35,20 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
     }
 
     @Test
-    fun `test get points on error`() = runBlockingTest {
+    fun `test get points on error`() {
         val throwable = Throwable()
-        whenever(mockGetUser.buildUseCase(any())) doReturn Result.failure(throwable)
+        coroutineScope.runBlockingTest { whenever(mockGetUser.buildUseCase(any())) doReturn Result.failure(throwable) }
         val useCase = GetUsePointsForUserIdCoroutineUseCase(mockGetUser)
         var points: Int? = null
         var exception: Throwable? = null
 
-        useCase(GetUsePointsForUserIdCoroutineUseCase.Params("userId"), {
-            points = it
-        }, {
-            exception = it
-        })
+        coroutineScope.runBlockingTest {
+            useCase(GetUsePointsForUserIdCoroutineUseCase.Params("userId"), {
+                points = it
+            }, {
+                exception = it
+            })
+        }
 
         assertThat(exception).isEqualTo(throwable)
         assertThat(points).isNull()

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUsePointsForUserIdCoroutineUseCaseTest.kt
@@ -6,21 +6,18 @@ import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import guru.stefma.cleancomponents.usecase.sample.jvm.Gender.FEMALE
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 
-@ObsoleteCoroutinesApi
+@ExperimentalCoroutinesApi
 class GetUsePointsForUserIdCoroutineUseCaseTest {
 
-    private val testContext = TestCoroutineScope()
+    private val coroutineScope = TestCoroutineScope()
 
     private val mockGetUser = mock<GetUserCoroutine>()
-
-    private val coroutineScope = CoroutineScope(testContext)
 
     @Test
     fun `test get points successfully`() {
@@ -33,7 +30,6 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
             points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId")).getOrNull()
         }
 
-        testContext.triggerActions()
         assertThat(points).isEqualTo(99)
     }
 
@@ -47,8 +43,7 @@ class GetUsePointsForUserIdCoroutineUseCaseTest {
             points = useCase.execute(GetUsePointsForUserIdCoroutineUseCase.Params("userId")).getOrNull()
         }
 
-        testContext.triggerActions()
-        assertThat(testContext.exceptions[0]).isInstanceOf(Throwable::class.java)
+        assertThat(coroutineScope.uncaughtExceptions[0]).isInstanceOf(Throwable::class.java)
         assertThat(points).isNull()
     }
 }

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
@@ -3,14 +3,14 @@ package guru.stefma.cleancomponents.usecase.sample.jvm
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestCoroutineContext
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.*
 
 @ObsoleteCoroutinesApi
 class GetUserCoroutineUseCaseTest {
 
-    private val testContext = TestCoroutineContext()
+    private val testContext = TestCoroutineScope()
 
     private val useCase = GetUserCoroutineUseCase()
 
@@ -19,11 +19,11 @@ class GetUserCoroutineUseCaseTest {
         var user: User? = null
 
         CoroutineScope(testContext).launch {
-            user = useCase.execute(GetUserCoroutineUseCase.Params("userId"))
+            user = useCase.execute(GetUserCoroutineUseCase.Params("userId")).getOrNull()
         }
 
         testContext.triggerActions()
-        assertThat(user).isNotNull()
+        assertThat(user).isNotNull
         user!!.apply {
             assertThat(id).isEqualTo("userId")
             assertThat(name).isEqualTo("Thorsten")

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
@@ -18,7 +18,7 @@ class GetUserCoroutineUseCaseTest {
         var user: User? = null
 
         coroutineScope.launch {
-            user = useCase.execute(GetUserCoroutineUseCase.Params("userId")).getOrNull()
+            user = useCase.buildUseCase(GetUserCoroutineUseCase.Params("userId")).getOrNull()
         }
 
         assertThat(user).isNotNull

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
@@ -1,13 +1,12 @@
 package guru.stefma.cleancomponents.usecase.sample.jvm
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.*
 
-@ObsoleteCoroutinesApi
+@ExperimentalCoroutinesApi
 class GetUserCoroutineUseCaseTest {
 
     private val testContext = TestCoroutineScope()
@@ -18,11 +17,10 @@ class GetUserCoroutineUseCaseTest {
     fun `test get user`() {
         var user: User? = null
 
-        CoroutineScope(testContext).launch {
+        testContext.launch {
             user = useCase.execute(GetUserCoroutineUseCase.Params("userId")).getOrNull()
         }
 
-        testContext.triggerActions()
         assertThat(user).isNotNull
         user!!.apply {
             assertThat(id).isEqualTo("userId")

--- a/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
+++ b/samples/jvm/src/test/java/guru/stefma/cleancomponents/usecase/sample/jvm/GetUserCoroutineUseCaseTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.*
 @ExperimentalCoroutinesApi
 class GetUserCoroutineUseCaseTest {
 
-    private val testContext = TestCoroutineScope()
+    private val coroutineScope = TestCoroutineScope()
 
     private val useCase = GetUserCoroutineUseCase()
 
@@ -17,7 +17,7 @@ class GetUserCoroutineUseCaseTest {
     fun `test get user`() {
         var user: User? = null
 
-        testContext.launch {
+        coroutineScope.launch {
             user = useCase.execute(GetUserCoroutineUseCase.Params("userId")).getOrNull()
         }
 

--- a/usekase-coroutines/build.gradle.kts
+++ b/usekase-coroutines/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm") version "1.3.40"
     id("com.novoda.bintray-release") version "0.9.1"
@@ -18,6 +20,13 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")
+}
+
+tasks.withType(KotlinCompile::class.java).all {
+    kotlinOptions.apply {
+        jvmTarget = "1.8"
+        freeCompilerArgs = listOf("-Xallow-result-return-type")
+    }
 }
 
 tasks.withType<Test> {

--- a/usekase-coroutines/build.gradle.kts
+++ b/usekase-coroutines/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.21"
+    kotlin("jvm") version "1.3.40"
     id("com.novoda.bintray-release") version "0.9.1"
 }
 
@@ -7,11 +7,15 @@ repositories {
     jcenter()
 }
 
+val coroutinesVersion = "1.2.1"
+
 dependencies {
     api(project(":usekase-annotation"))
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+
     implementation(kotlin("stdlib-jdk7"))
 
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")
 }
@@ -26,7 +30,7 @@ publish {
     artifactId = "usekase-coroutines"
     uploadName = "UseKase"
     publishVersion = "1.0.0"
-    desc = "Provides a corotuine UseCase implementation for the Clean Architecture"
+    desc = "Provides a coroutine UseCase implementation for the Clean Architecture"
     website = "https://github.com/StefMa/UseKase"
     setLicences("MIT")
 }

--- a/usekase-coroutines/build.gradle.kts
+++ b/usekase-coroutines/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.40"
+    kotlin("jvm") version "1.3.41"
     id("com.novoda.bintray-release") version "0.9.1"
 }
 
@@ -9,7 +9,7 @@ repositories {
     jcenter()
 }
 
-val coroutinesVersion = "1.2.1"
+val coroutinesVersion = "1.2.2"
 
 dependencies {
     api(project(":usekase-annotation"))
@@ -19,7 +19,7 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.0")
-    testImplementation("org.assertj:assertj-core:3.12.1")
+    testImplementation("org.assertj:assertj-core:3.12.2")
 }
 
 tasks.withType(KotlinCompile::class.java).configureEach {

--- a/usekase-coroutines/build.gradle.kts
+++ b/usekase-coroutines/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.12.1")
 }
 
-tasks.withType(KotlinCompile::class.java).all {
+tasks.withType(KotlinCompile::class.java).configureEach {
     kotlinOptions.apply {
         jvmTarget = "1.8"
         freeCompilerArgs = listOf("-Xallow-result-return-type")

--- a/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
+++ b/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * Use this base class to create a use case with input [parameters][Params] and an expected [result][Type].
  *
- * By default, once your overridden [execute] method returns, the callback lambdas passed to [invoke] will execute
+ * By default, once your overridden [buildUseCase] method returns, the callback lambdas passed to [invoke] will buildUseCase
  * on the [main thread][Dispatchers.Main]. This requires a runtime dependency of coroutines that adds a main
  * dispatcher. You can override [callbackDispatcher] to change this behavior.
  *
@@ -25,10 +25,10 @@ interface CoroutineUseCase<out Type, in Params> where Type : Any {
     /**
      * Runs the actual logic of the use case.
      */
-    suspend fun execute(params: Params): Result<Type>
+    suspend fun buildUseCase(params: Params): Result<Type>
 
     suspend operator fun invoke(params: Params, onSuccess: (Type) -> Unit, onFailure: (Throwable) -> Unit) {
-        val result = execute(params)
+        val result = buildUseCase(params)
 
         coroutineScope {
             launch(callbackDispatcher) {

--- a/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
+++ b/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
@@ -17,14 +17,15 @@ import kotlin.coroutines.CoroutineContext
  * @param Type The type which you expect to be returned by the use case.
  * @param Params The parameters which the use case needs as an input.
  */
-abstract class CoroutineUseCase<out Type, in Params> where Type : Any {
+interface CoroutineUseCase<out Type, in Params> where Type : Any {
 
-    open val callbackDispatcher: CoroutineContext = Dispatchers.Main
+    val callbackDispatcher: CoroutineContext
+        get() = Dispatchers.Main
 
     /**
      * Runs the actual logic of the use case.
      */
-    abstract suspend fun execute(params: Params): Result<Type>
+    suspend fun execute(params: Params): Result<Type>
 
     suspend operator fun invoke(params: Params, onSuccess: (Type) -> Unit, onFailure: (Throwable) -> Unit) {
         val result = execute(params)

--- a/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
+++ b/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
@@ -1,17 +1,41 @@
 package guru.stefma.cleancomponents.usecase.coroutines
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
 /**
- * A UseCase is a "actor" or "transformer" in the clean architecture.
+ * A UseCase is an "actor" or "transformer" in the Clean Architecture.
  *
- * Use this interface as a default implementation of an interface which have [params][P] and a [result][R].
+ * Use this base class to create a use case with input [parameters][Params] and an expected [result][Type].
  *
- * Simply call [execute] with the given [params][P] to get the [result][R].
+ * By default, once your overridden [execute] method returns, the callback lambdas passed to [invoke] will execute
+ * on the [main thread][Dispatchers.Main]. This requires a runtime dependency of coroutines that adds a main
+ * dispatcher. You can override [callbackDispatcher] to change this behavior.
  *
- * @param P the params you want to put in to the UseCase
- * @param R the result value which will be emitted by this UseCase
+ * @param Type The type which you expect to be returned by the use case.
+ * @param Params The parameters which the use case needs as an input.
  */
-interface CoroutineUseCase<R, P> {
+abstract class CoroutineUseCase<out Type, in Params> where Type : Any {
 
-    suspend fun execute(params: P): R
+    open val callbackDispatcher: CoroutineContext = Dispatchers.Main
 
+    /**
+     * Runs the actual logic of the use case.
+     */
+    abstract suspend fun execute(params: Params): Type
+
+    suspend operator fun invoke(params: Params, onSuccess: (Type) -> Unit, onFailure: (Throwable) -> Unit) {
+        val result = runCatching { execute(params) }
+
+        coroutineScope {
+            launch(callbackDispatcher) {
+                result.fold(
+                    onFailure = onFailure,
+                    onSuccess = onSuccess
+                )
+            }
+        }
+    }
 }

--- a/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
+++ b/usekase-coroutines/src/main/kotlin/guru/stefma/cleancomponents/usecase/coroutines/CoroutineUseCase.kt
@@ -24,10 +24,10 @@ abstract class CoroutineUseCase<out Type, in Params> where Type : Any {
     /**
      * Runs the actual logic of the use case.
      */
-    abstract suspend fun execute(params: Params): Type
+    abstract suspend fun execute(params: Params): Result<Type>
 
     suspend operator fun invoke(params: Params, onSuccess: (Type) -> Unit, onFailure: (Throwable) -> Unit) {
-        val result = runCatching { execute(params) }
+        val result = execute(params)
 
         coroutineScope {
             launch(callbackDispatcher) {

--- a/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
+++ b/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
@@ -40,7 +40,7 @@ class UseCaseTest {
         assertThat(result).isEqualTo(successResult)
     }
 
-    inner class DefaultCoroutineUseCase : CoroutineUseCase<String, Unit>() {
+    inner class DefaultCoroutineUseCase : CoroutineUseCase<String, Unit> {
 
         override suspend fun buildUseCase(params: Unit): Result<String> {
             return Result.success(successResult)

--- a/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
+++ b/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
@@ -3,6 +3,7 @@ package guru.stefma.cleancomponents.usecase.coroutines
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
@@ -17,6 +18,8 @@ class UseCaseTest {
 
     private val mainThreadSurrogate = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 
+    private val coroutineScope = TestCoroutineScope()
+
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainThreadSurrogate)
@@ -29,14 +32,15 @@ class UseCaseTest {
     }
 
     @Test
-    fun `default coroutineusecase`() = runBlockingTest {
+    fun `default coroutineusecase`() {
         val useCaseImpl = DefaultCoroutineUseCase()
 
         lateinit var result: String
-        useCaseImpl(Unit,
-            onSuccess = { result = it },
-            onFailure = { fail(it) })
-
+        coroutineScope.runBlockingTest {
+            useCaseImpl(Unit,
+                onSuccess = { result = it },
+                onFailure = { fail(it) })
+        }
         assertThat(result).isEqualTo(successResult)
     }
 

--- a/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
+++ b/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
@@ -42,8 +42,8 @@ class UseCaseTest {
 
     inner class DefaultCoroutineUseCase : CoroutineUseCase<String, Unit>() {
 
-        override suspend fun execute(params: Unit): String {
-            return successResult
+        override suspend fun execute(params: Unit): Result<String> {
+            return Result.success(successResult)
         }
     }
 }

--- a/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
+++ b/usekase-coroutines/src/test/kotlin/guru/stefma/cleancomponents/usecase/coroutines/UseCaseTest.kt
@@ -42,7 +42,7 @@ class UseCaseTest {
 
     inner class DefaultCoroutineUseCase : CoroutineUseCase<String, Unit>() {
 
-        override suspend fun execute(params: Unit): Result<String> {
+        override suspend fun buildUseCase(params: Unit): Result<String> {
             return Result.success(successResult)
         }
     }

--- a/usekase-rx/build.gradle.kts
+++ b/usekase-rx/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     api(project(":usekase"))
     implementation(kotlin("stdlib-jdk7"))
-    implementation("io.reactivex.rxjava2:rxjava:2.2.7")
+    api("io.reactivex.rxjava2:rxjava:2.2.7")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.0")
     testImplementation("org.assertj:assertj-core:3.12.1")


### PR DESCRIPTION
Changes the coroutines use case to the one I used in the Kotlin MP project.

In the MPP project I used the `Either` class, but I found a way to use Kotlin's `Result` class instead, using `runCatching`, which is actually better, since in the MPP project I manually used `try catch` to only return `Failure` in the catch-block, which is done automatically now.

For convenience, the callbacks are launched on the Main thread, since I think this is the most common use case. This requires a runtime dependency to something that has a Main dispatcher (e.g. coroutines Android or Swing).
